### PR TITLE
Fix: discriminator lost in extraction

### DIFF
--- a/src/Form/Element/NonuniformCollection.php
+++ b/src/Form/Element/NonuniformCollection.php
@@ -239,6 +239,11 @@ class NonuniformCollection extends Collection
                 $targetElement = clone $this->targetElement[$discriminator];
                 $targetElement->object = $value;
                 $values[$key] = $targetElement->extract();
+                
+                if (!isset($values[$key][$discrKey])) {
+                    $values[$key][$discrKey] = $discriminator;
+                }
+                
                 if ($this->has($key)) {
                     $fieldset = $this->get($key);
                     if ($fieldset instanceof Fieldset && $fieldset->allowObjectBinding($value)) {


### PR DESCRIPTION
If you use doctrine, the discrimator field is not part of the hydration. This PR readds the discriminator, if it's lost by the hydrator. Especially for use with doctrine 2.