### PR TITLE
Fixed Exception

### DIFF
--- a/src/InputFilter/NonuniformCollectionInputFilter.php
+++ b/src/InputFilter/NonuniformCollectionInputFilter.php
@@ -127,7 +127,9 @@ class NonuniformCollectionInputFilter extends CollectionInputFilter
             if (! isset($filterSet[$data[$discrKey]])) {
                 $valid = false;
                 $this->collectionMessages[$key] = array(
-                    $discrKey => sprintf('Could not map provided value (%s) to an input filter', $data[$discrKey]),
+                    $discrKey => [
+						sprintf('Could not map provided value (%s) to an input filter', $data[$discrKey]),
+					]
                 );
                 $this->invalidInputs[$key] = array(
                     $discrKey => $data[$discrKey],


### PR DESCRIPTION
Zend\Form\Element->setMessages(..) expects an Array or Traversable. Without this fix I always recive the following exception:
```Zend\Form\Element::setMessages expects an array or Traversable object of validation error messages; received "string"```